### PR TITLE
Support for minimising the steering angle difference between previous and next angle

### DIFF
--- a/swerve_controller/include/swerve_controller/swerve_controller.h
+++ b/swerve_controller/include/swerve_controller/swerve_controller.h
@@ -40,6 +40,7 @@
 #include <cmath>
 #include <string>
 #include <boost/optional.hpp>
+#include <algorithm>
 
 #include <controller_interface/multi_interface_controller.h>
 #include <hardware_interface/joint_command_interface.h>
@@ -148,11 +149,20 @@ namespace swerve_controller
         /// Whether to publish odometry to tf or not:
         bool enable_odom_tf_;
 
+        // Whether to enable minimum steering difference by checking whether the calculated angle or its
+        // polar opposite angle are closer to the previously set one
+        bool enable_min_steering_difference_;
+
         /// Speed limiters:
         CommandTwist last1_cmd_;
         CommandTwist last0_cmd_;
         SpeedLimiter limiter_lin_;
         SpeedLimiter limiter_ang_;
+
+        double lf_steering_last;
+        double rf_steering_last;
+        double lh_steering_last;
+        double rh_steering_last;
 
     private:
         void updateOdometry(const ros::Time &time);
@@ -160,6 +170,8 @@ namespace swerve_controller
         void updateCommand(const ros::Time &time, const ros::Duration &period);
 
         void brake();
+
+        void minSteeringDifference(double &steering, double &previous_steering, double &speed);
 
         bool clipSteeringAngle(double &steering, double &speed);
 

--- a/swerve_controller/test/config/swervebot_control.yaml
+++ b/swerve_controller/test/config/swervebot_control.yaml
@@ -19,8 +19,11 @@ swervebot:
         rh_steering: "leg_rh_joint"
 
         # Range of motion of steering motors
-        min_steering_angle: -1.58
-        max_steering_angle: 1.58
+        # min_steering_angle: -1.58
+        # max_steering_angle: 1.58
+
+        # Minimise steering difference between previous and next steering angle (continuous steering joints only)
+        # enable_min_steering_difference: true
 
         # Other
         publish_rate: 50


### PR DESCRIPTION
This enhancement makes the controller behave optimally when selecting steering angles on continuous joint steering based robots.

To find the optimal angle to select we find the minimum angle difference between the previous angle position issued and either the calculated steering joint angle or it's polar opposite angle. When chosing the lesser difference we can gaurantee that the joint never moves more than π/2 radians per turn as opposed to the π radians per turn maxium in the current repo state.

More information on this can be found in [this comment ](https://github.com/ros-controls/ros_controllers/pull/441#issuecomment-678972950). I wasn't sure how we could make simple tests for this enhancement, we'd have to add another monitor to the test code that checks the joint_states prior and post command. 

Let me know if you wan't any other work done, you can then merge my work into your existing ros-control pull request. We could also wait until your original code has passed but PR's take a very long time to get checked over so I thought it might be fast this way.

Cheers!